### PR TITLE
chore: add type interfaces of users data

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,3 +1,7 @@
+// types
+import { IUserItem } from '@/types/user';
+import { ILandlordDetail, IStudentDetail } from '@/types/detail';
+
 // students
 import studentUsersJson from './student-users.json';
 import studentDetailsJson from './student-details.json';
@@ -10,14 +14,13 @@ import landlordDetailsJson from './landlord-details.json';
 export const studentUsers = studentUsersJson.map((user) => ({
   ...user,
   avatarUrl: `${process.env.NEXT_PUBLIC_HOST_URL}${user.avatarUrl}`,
-}));
+})) as Array<IUserItem>;
+
+export const studentDetails = studentDetailsJson as Array<IStudentDetail>;
 
 export const landlordUsers = landlordUsersJson.map((user) => ({
   ...user,
   avatarUrl: `${process.env.NEXT_PUBLIC_HOST_URL}${user.avatarUrl}`,
-}));
+})) as Array<IUserItem>;
 
-export {
-  studentDetailsJson as studentDetails,
-  landlordDetailsJson as landlordDetails,
-};
+export const landlordDetails = landlordDetailsJson as Array<ILandlordDetail>;

--- a/src/types/detail.ts
+++ b/src/types/detail.ts
@@ -1,0 +1,20 @@
+// ----------------------------------------------------------------------
+
+export interface ILandlordDetail {
+  id: string;
+  userId: string;
+  housingName: string;
+  chatLink: string | null;
+  mapLink: string | null;
+}
+
+export interface IStudentDetail {
+  id: string;
+  userId: string;
+  studentId: string;
+  degree: string;
+  department: string;
+  college: string;
+  housingId: string | null;
+  applicationId: string | null;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,40 @@
+import { ILandlordDetail, IStudentDetail } from './detail';
+
+// ----------------------------------------------------------------------
+
+export interface IUserItem {
+  id: string;
+  username: string;
+  password: string;
+  role: string;
+  firstName: string;
+  lastName: string;
+  middleName: string;
+  nameExtension: string | null;
+  fullName: string;
+  dateOfBirth: Date | string;
+  gender: string;
+  email: string;
+  phoneNumber: string;
+  addressLine1: string;
+  addressLine2: string;
+  addressLine3: string;
+  addressLine4: string;
+  avatarUrl: string | null;
+  createdAt: Date | string | null;
+  createdBy: string | null;
+  updatedAt: Date | string | null;
+  updatedBy: string | null;
+  deletedAt: Date | string | null;
+  deletedBy: string | null;
+}
+
+// ----------------------------------------------------------------------
+
+export interface UserLandlordResponse extends Omit<IUserItem, 'password'> {
+  details: Omit<ILandlordDetail, 'userId'>;
+}
+
+export interface UserStudentResponse extends Omit<IUserItem, 'password'> {
+  details: Omit<IStudentDetail, 'id' | 'userId'>;
+}


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homepage" --->

Add type interfaces of student and landlord users data.

### Changes:

<!--- Bullet points of changes made --->

- add interface of users
- add interface of student and landlord details
- add interface of API responses for both users
- apply interfaces to JSON data

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

N/A

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
