### PR TITLE
feat: add post list api

### DIFF
--- a/src/app/api/post/list/route.ts
+++ b/src/app/api/post/list/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// data
+import { landlordDetails, landlordUsers, postList, postUploads } from '@/data';
+// types
+import { IUserItem } from '@/types/user';
+import { ILandlordDetail } from '@/types/detail';
+import { IUploadItem, PostResponse } from '@/types/post';
+
+// ----------------------------------------------------------------------
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const withUserParam = searchParams.get('createdBy');
+
+  const isWithUser = withUserParam === 'true';
+
+  if (withUserParam && !isWithUser) {
+    return NextResponse.json(
+      { message: 'Invalid query parameter. Use "createdBy=true" to include landlord details.' },
+      { status: 400 }
+    );
+  }
+
+  //#region Fetching data
+  const result: PostResponse[] = postList.map((_p) => {
+    const detail = landlordDetails.find((_d) => _d.id === _p.housingId) || ({} as ILandlordDetail);
+
+    const user = landlordUsers.find((_u) => _u.id === detail.userId) || ({} as IUserItem);
+
+    const uploads = postUploads.filter((_u) => _u.postId === _p.id) || ([] as IUploadItem[]);
+
+    return {
+      ..._p,
+      housingId: undefined, // Exclude housingId from the response
+      uploads: uploads.map((_u) => ({
+        ..._u,
+        postId: undefined, // Exclude postId from the response
+      })),
+      createdBy: isWithUser
+        ? {
+            ...user,
+            details: detail,
+          }
+        : undefined, // Include landlord details if createdBy is true
+    };
+  });
+  //#endregion
+
+  if (!result.length) {
+    return NextResponse.json({ message: 'No results found.' }, { status: 404 });
+  }
+
+  return NextResponse.json(result, { status: 200 });
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -10,6 +10,7 @@ import postUploadsJson from './post-uploads.json';
 
 // types
 import { IUserItem } from '@/types/user';
+import { IPostItem, IUploadItem } from '@/types/post';
 import { ILandlordDetail, IStudentDetail } from '@/types/detail';
 
 // ----------------------------------------------------------------------
@@ -28,9 +29,9 @@ export const landlordUsers = landlordUsersJson.map((user) => ({
 
 export const landlordDetails = landlordDetailsJson as Array<ILandlordDetail>;
 
-export const postList = postListJson;
+export const postList = postListJson as Array<IPostItem>;
 
 export const postUploads = postUploadsJson.map((upload) => ({
   ...upload,
   imageUrl: `${process.env.NEXT_PUBLIC_HOST_URL}${upload.imgUrl}`,
-}));
+})) as Array<IUploadItem>;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,28 @@
+import { UserLandlordResponse } from './user';
+
+// ----------------------------------------------------------------------
+
+export interface IPostItem {
+  id: string;
+  housingId: string;
+  title: string;
+  description: string;
+  price: number;
+  isVisible: boolean;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  deletedAt: Date | string | null;
+}
+
+export interface IUploadItem {
+  id: string;
+  postId: string;
+  imgUrl: string;
+}
+
+// ----------------------------------------------------------------------
+
+export interface PostResponse extends Omit<IPostItem, 'housingId'> {
+  uploads: Omit<IUploadItem, 'postId'>[];
+  createdBy?: UserLandlordResponse;
+}


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homepage" --->

Adds API for listing Posts w/ `createdBy` boolean params.

### Changes:

<!--- Bullet points of changes made --->

- add type interfaces for posts and uploads data
- add type interface for post list API response
- add API route for Posts list

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

N/A

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
