### PR TITLE
feat: add post details api

### DIFF
--- a/src/app/api/post/list/[id]/route.ts
+++ b/src/app/api/post/list/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// data
+import { landlordDetails, landlordUsers, postList, postUploads } from '@/data';
+// types
+import { IUserItem } from '@/types/user';
+import { ILandlordDetail } from '@/types/detail';
+import { IUploadItem, PostResponse } from '@/types/post';
+
+// ----------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const { searchParams } = request.nextUrl;
+
+  const withUserParam = searchParams.get('createdBy');
+
+  const isWithUser = withUserParam === 'true';
+
+  if (withUserParam && !isWithUser) {
+    return NextResponse.json(
+      { message: 'Invalid query parameter. Use "createdBy=true" to include landlord details.' },
+      { status: 400 }
+    );
+  }
+
+  const postById = postList.find((_p) => _p.id === id);
+
+  if (!postById) {
+    return NextResponse.json({ message: 'Post not found.' }, { status: 404 });
+  }
+
+  const detail =
+    landlordDetails.find((_d) => _d.id === postById.housingId) || ({} as ILandlordDetail);
+
+  const user = landlordUsers.find((_u) => _u.id === detail.userId) || ({} as IUserItem);
+
+  const uploads = postUploads.filter((_u) => _u.postId === postById.id) || ([] as IUploadItem[]);
+
+  const result: PostResponse = {
+    ...(({ housingId, ...rest }) => rest)(postById), // Exclude `housingId` from the response
+    uploads: uploads.map((_u) => ({
+      ...(({ postId, ...rest }) => rest)(_u), // Exclude `postId` from the response
+    })),
+    createdBy: isWithUser
+      ? {
+          ...(({ password, ...rest }) => rest)(user), // Exclude `password` from the response
+          details: (({ userId, ...rest }) => rest)(detail), // Exclude `userId` from the response
+        }
+      : undefined, // Include landlord details if createdBy is true
+  };
+
+  return NextResponse.json(result, { status: 200 });
+}

--- a/src/app/api/post/list/route.ts
+++ b/src/app/api/post/list/route.ts
@@ -9,6 +9,7 @@ import { IUploadItem, PostResponse } from '@/types/post';
 
 // ----------------------------------------------------------------------
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
 
@@ -32,16 +33,14 @@ export async function GET(request: NextRequest) {
     const uploads = postUploads.filter((_u) => _u.postId === _p.id) || ([] as IUploadItem[]);
 
     return {
-      ..._p,
-      housingId: undefined, // Exclude `housingId` from the response
+      ...(({ housingId, ...rest }) => rest)(_p), // Exclude `housingId` from the response
       uploads: uploads.map((_u) => ({
-        ..._u,
-        postId: undefined, // Exclude `postId` from the response
+        ...(({ postId, ...rest }) => rest)(_u), // Exclude `postId` from the response
       })),
       createdBy: isWithUser
         ? {
-            ...user,
-            details: detail,
+            ...(({ password, ...rest }) => rest)(user), // Exclude `password` from the response
+            details: (({ userId, ...rest }) => rest)(detail), // Exclude `userId` from the response
           }
         : undefined, // Include landlord details if createdBy is true
     };


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homepage" --->

Adds API for fetching individual Post details by id.

### Changes:

<!--- Bullet points of changes made --->

- add API route for post details : `api/post/list/:id`

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

N/A

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
