### PR TITLE
feat(auth): add auth me api

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// utils
+import authenticateAccessToken from '@/utils/auth-token';
+// data
+import { landlordDetails, landlordUsers, studentDetails, studentUsers } from '@/data';
+// types
+import { ILandlordDetail, IStudentDetail } from '@/types/detail';
+import { DemoLandlordResponse, DemoStudentResponse } from '@/types/demo';
+
+// ----------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateAccessToken(request);
+
+  if (auth instanceof NextRequest) {
+    return auth; // Return the NextResponse if authentication failed
+  }
+
+  const user = auth as { id: string; email: string };
+
+  const userList = [...landlordUsers, ...studentUsers];
+
+  //#region Checking user
+  const foundUser = userList.find((_u) => _u.id === user.id);
+
+  if (!foundUser) {
+    return NextResponse.json({ message: 'User not found.' }, { status: 404 });
+  }
+  //#endregion
+
+  if (foundUser.role === 'landlord') {
+    const detailById =
+      landlordDetails.find((_d) => _d.userId === foundUser.id) || ({} as ILandlordDetail);
+
+    const result: DemoLandlordResponse = {
+      ...(({ password, ...rest }) => rest)(foundUser), // Exclude `password` from the response
+      details: (({ userId, ...rest }) => rest)(detailById), // Exclude `userId` from the response
+    };
+
+    return NextResponse.json({ user: result }, { status: 200 });
+  }
+
+  if (foundUser.role === 'student') {
+    const detailById =
+      studentDetails.find((_d) => _d.userId === foundUser.id) || ({} as IStudentDetail);
+
+    const result: DemoStudentResponse = {
+      ...(({ password, ...rest }) => rest)(foundUser), // Exclude `password` from the response
+      details: (({ id, userId, ...rest }) => rest)(detailById), // Exclude `id` and `userId` from the response
+    };
+
+    return NextResponse.json({ user: result }, { status: 200 });
+  }
+
+  const result = (({ password, ...rest }) => rest)(foundUser); // Exclude `password` from the response
+
+  return NextResponse.json({ user: result }, { status: 200 });
+}

--- a/src/types/demo.ts
+++ b/src/types/demo.ts
@@ -1,0 +1,7 @@
+import { UserLandlordResponse, UserStudentResponse } from './user';
+
+// ----------------------------------------------------------------------
+
+export interface DemoLandlordResponse extends UserLandlordResponse {}
+
+export interface DemoStudentResponse extends UserStudentResponse {}

--- a/src/utils/auth-token.ts
+++ b/src/utils/auth-token.ts
@@ -1,0 +1,22 @@
+import jwt from 'jsonwebtoken';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ----------------------------------------------------------------------
+
+const SECRET_KEY = process.env.NEXT_PUBLIC_JWT_SECRET_ACCESS_KEY as string;
+
+export default async function authenticateAccessToken(request: NextRequest) {
+  const token = request.headers.get('Authorization')?.split(' ')[1];
+
+  if (!token) {
+    return NextResponse.json({ message: 'No token provided.' }, { status: 401 });
+  }
+
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
+
+    return decoded;
+  } catch {
+    return NextResponse.json({ message: 'Invalid or expired token.' }, { status: 401 });
+  }
+}


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homepage" --->

Adds API for fetching data of authenticated user.

### Changes:

<!--- Bullet points of changes made --->

- add API route for auth user data : `api/auth/me`
- create `authenticateAccessToken` util

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

N/A

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
